### PR TITLE
Performance improvement

### DIFF
--- a/lys_em/multislice.py
+++ b/lys_em/multislice.py
@@ -1,7 +1,6 @@
 import jax
 import jax.numpy as jnp
 from jax.sharding import PartitionSpec as P
-from jax.ad_checkpoint import checkpoint
 
 def multislice(pot, tem, probe="TEM", use_checkpoint=False):
     """
@@ -23,33 +22,34 @@ def multislice(pot, tem, probe="TEM", use_checkpoint=False):
     sp = pot.space.asdict()
     params = tem.asdict(len(jax.devices()))
     t_r = pot.getTransmissionFunction(tem)
+    probes = probe if not isinstance(probe, str) else jnp.array([jnp.fft.ifft2(jnp.ones(pot.space.N[:2]))])
     f = checkpoint(run_single_param) if use_checkpoint else run_single_param
 
-    def _loop(_, tem_i):
-        phi = getWaveFunction(sp, tem_i, probe) # shape (nprobe, Nx, Ny)
+    @jax.jit
+    def _loop(tem_i):
+        phi = getWaveFunction(sp, tem_i, probes) # shape (nprobe, Nx, Ny)
         phi = f(phi,sp, tem_i, t_r)
 
         # Apply abberration for TEM
         if probe == "TEM":
             H = getAberrationFunction(sp, tem_i)  # shape (Nx, Ny)
             phi = jnp.fft.ifft2(jnp.fft.fft2(phi, axes=(-2,-1)) * H * sp["mask"], axes=(-2,-1))
-        return _, phi
+        return phi
 
     # Parallelization: "calc" function perform multislice calculation for list of parameters in tem. 
-    calc = shard_map(lambda x: jax.lax.scan(_loop, None, x)[1],
+    calc = shard_map(lambda x: jax.lax.map(_loop,x),
                         mesh=jax.sharding.Mesh(jax.devices(), ('i',)), in_specs=P('i'), out_specs=P('i',None,None,None))
 
-    # Remove padding and unnecessary axis
-    phi = calc(params)[:tem.num_params].squeeze()
-    return phi
+    # Move to main, remove padding and unnecessary axis
+    phi = jax.device_get(calc(params))    # (nparams, nprobe, Nx, Ny)
+    return phi[:tem.num_params].squeeze()
 
 
 @jax.jit
 def run_single_param(phi, sp, tem, t_r):
     P_k = getPropagationTerm(sp, tem) # shape (Nx, Ny)
     step = lambda phi, V: (jnp.fft.ifft2(jnp.fft.fft2(phi * V) * P_k), 0)
-    phi = jax.lax.scan(step, phi, t_r)[0]
-    return phi
+    return jax.lax.scan(step, phi, t_r)[0]
 
 
 @jax.jit
@@ -93,6 +93,8 @@ def getPropagationTerm(sp, tem):
     theta = _cartesianBeamTilt(jnp.deg2rad(tilt))
     return _propagationTerm(theta)
 
+
+@jax.jit
 def getWaveFunction(sp, tem, probe="TEM"):
     """
     Calculate the wave function of the multislice simulation.
@@ -119,15 +121,8 @@ def getWaveFunction(sp, tem, probe="TEM"):
         return jnp.where(k_norm <= k_max, arr, 0j)
 
     chi = getChi(sp, tem)
-
-    if type(probe) is str and probe in ["TEM", "STEM"]:
-        probes = _mask(jnp.exp(-1j * chi(defocus)))
-    else:
-        probes = _mask(jnp.fft.fft2(probe)*jnp.exp(-1j * chi(defocus)))
-
+    probes = _mask(jnp.fft.fft2(probe)*jnp.exp(-1j * chi(defocus)))
     phi = _shiftProbe(probes, position)
-    if phi.ndim == 2:
-        phi = jnp.expand_dims(phi, axis=0)    # Virtually consider multiple probes
     return phi
 
 
@@ -172,6 +167,7 @@ def getChi(sp, tem):
     l = tem["wavelength"]  # A
     Cs = tem["Cs"]  # A
 
+    @jax.jit
     def _chi(df):  # df : A
         return 2 * jnp.pi / l * (Cs * ((l * k)**4) / 4 - df * ((l * k)**2) / 2)
 

--- a/lys_em/multislice.py
+++ b/lys_em/multislice.py
@@ -19,13 +19,13 @@ def multislice(pot, tem, probe="TEM", postprocess="square", sum=False, use_check
     Returns:
         phi (numpy.ndarray) : The multislice simulation result.
     """
-
+    sp = pot.space
     postprocess = init_postprocess(postprocess)
 
     params = tem.asdict(len(jax.devices()))
     calc_phi = single_func(pot, tem, probe, use_checkpoint=use_checkpoint)
     
-    init = jnp.zeros((1,512,512), dtype=jnp.float32)
+    init = jnp.zeros((1 if isinstance(probe, str) else len(probe),sp.N[0],sp.N[1]), dtype=jnp.float32)
     @jax.jit
     @checkpoint
     def local_dev(x):
@@ -33,7 +33,7 @@ def multislice(pot, tem, probe="TEM", postprocess="square", sum=False, use_check
         def _post(carry, param):
             phi = calc_phi(param)
             post = postprocess(phi)
-            return carry + post, None
+            return carry + post, None if sum else post
         
         summed, all = jax.lax.scan(_post, init_varying, x)
         if sum:
@@ -58,7 +58,6 @@ def init_postprocess(post):
 
 
 def single_func(pot, tem, probe, use_checkpoint=False):
-    checkpoint = jax.checkpoint if hasattr(jax, 'checkpoint') else jax.ad_checkpoint.checkpoint
     sp = pot.space.asdict()
     t_r = pot.getTransmissionFunction(tem)
     probes = probe if not isinstance(probe, str) else jnp.array([jnp.fft.ifft2(jnp.ones(pot.space.N[:2]))])
@@ -66,11 +65,13 @@ def single_func(pot, tem, probe, use_checkpoint=False):
     @jax.jit
     def run_single_param(phi, sp, tem, t_r):
         P_k = getPropagationTerm(sp, tem) # shape (Nx, Ny)
-        step = lambda phi, V: (jnp.fft.ifft2(jnp.fft.fft2(phi * V) * P_k), 0)
-        return jax.lax.scan(step, phi, t_r)[0]
+        step = lambda i, phi: jnp.fft.ifft2(jnp.fft.fft2(phi * t_r[i]) * P_k)
+        step = checkpoint(step)
+        return jax.lax.fori_loop(0, len(t_r), step, phi)
     run_single_param = checkpoint(run_single_param) if use_checkpoint else run_single_param
 
     @jax.jit
+    @checkpoint
     def _loop(tem_i):
         phi = getWaveFunction(sp, tem_i, probes) # shape (nprobe, Nx, Ny)
         phi = run_single_param(phi,sp, tem_i, t_r)

--- a/lys_em/multislice.py
+++ b/lys_em/multislice.py
@@ -2,7 +2,11 @@ import jax
 import jax.numpy as jnp
 from jax.sharding import PartitionSpec as P
 
-def multislice(pot, tem, probe="TEM", use_checkpoint=False):
+checkpoint = jax.checkpoint if hasattr(jax, 'checkpoint') else jax.ad_checkpoint.checkpoint
+shard_map = jax.shard_map if hasattr(jax, 'shard_map') else jax.experimental.shard_map.shard_map
+
+
+def multislice(pot, tem, probe="TEM", postprocess="square", sum=False, use_checkpoint=False):
     """
     Calculate the multislice simulation.
 
@@ -16,19 +20,60 @@ def multislice(pot, tem, probe="TEM", use_checkpoint=False):
         phi (numpy.ndarray) : The multislice simulation result.
     """
 
-    shard_map = jax.shard_map if hasattr(jax, 'shard_map') else jax.experimental.shard_map.shard_map
-    checkpoint = jax.checkpoint if hasattr(jax, 'checkpoint') else jax.ad_checkpoint.checkpoint
+    postprocess = init_postprocess(postprocess)
 
-    sp = pot.space.asdict()
     params = tem.asdict(len(jax.devices()))
+    calc_phi = single_func(pot, tem, probe, use_checkpoint=use_checkpoint)
+    
+    init = jnp.zeros((1,512,512), dtype=jnp.float32)
+    @jax.jit
+    @checkpoint
+    def local_dev(x):
+        init_varying = jax.lax.pcast(init, "i", to="varying")
+        def _post(carry, param):
+            phi = calc_phi(param)
+            post = postprocess(phi)
+            return carry + post, None
+        
+        summed, all = jax.lax.scan(_post, init_varying, x)
+        if sum:
+            return jax.lax.psum(summed, "i")
+        else:
+            return all
+
+    # Parallelization: "calc" function perform multislice calculation for list of parameters in tem. 
+    calc = shard_map(local_dev,
+            mesh=jax.sharding.Mesh(jax.devices(), ('i',)), in_specs=P('i'), out_specs= P(None,None,None) if sum else P('i',None,None,None))
+
+    # Move to main, remove padding and unnecessary axis
+    phi = jax.device_get(calc(params))    # (nparams, nprobe, Nx, Ny)
+    return phi
+
+
+def init_postprocess(post):
+    if post is None:
+        return lambda x: x
+    elif post == "square":
+        return lambda x: abs(x)**2
+
+
+def single_func(pot, tem, probe, use_checkpoint=False):
+    checkpoint = jax.checkpoint if hasattr(jax, 'checkpoint') else jax.ad_checkpoint.checkpoint
+    sp = pot.space.asdict()
     t_r = pot.getTransmissionFunction(tem)
     probes = probe if not isinstance(probe, str) else jnp.array([jnp.fft.ifft2(jnp.ones(pot.space.N[:2]))])
-    f = checkpoint(run_single_param) if use_checkpoint else run_single_param
+
+    @jax.jit
+    def run_single_param(phi, sp, tem, t_r):
+        P_k = getPropagationTerm(sp, tem) # shape (Nx, Ny)
+        step = lambda phi, V: (jnp.fft.ifft2(jnp.fft.fft2(phi * V) * P_k), 0)
+        return jax.lax.scan(step, phi, t_r)[0]
+    run_single_param = checkpoint(run_single_param) if use_checkpoint else run_single_param
 
     @jax.jit
     def _loop(tem_i):
         phi = getWaveFunction(sp, tem_i, probes) # shape (nprobe, Nx, Ny)
-        phi = f(phi,sp, tem_i, t_r)
+        phi = run_single_param(phi,sp, tem_i, t_r)
 
         # Apply abberration for TEM
         if probe == "TEM":
@@ -36,20 +81,7 @@ def multislice(pot, tem, probe="TEM", use_checkpoint=False):
             phi = jnp.fft.ifft2(jnp.fft.fft2(phi, axes=(-2,-1)) * H * sp["mask"], axes=(-2,-1))
         return phi
 
-    # Parallelization: "calc" function perform multislice calculation for list of parameters in tem. 
-    calc = shard_map(lambda x: jax.lax.map(_loop,x),
-                        mesh=jax.sharding.Mesh(jax.devices(), ('i',)), in_specs=P('i'), out_specs=P('i',None,None,None))
-
-    # Move to main, remove padding and unnecessary axis
-    phi = jax.device_get(calc(params))    # (nparams, nprobe, Nx, Ny)
-    return phi[:tem.num_params].squeeze()
-
-
-@jax.jit
-def run_single_param(phi, sp, tem, t_r):
-    P_k = getPropagationTerm(sp, tem) # shape (Nx, Ny)
-    step = lambda phi, V: (jnp.fft.ifft2(jnp.fft.fft2(phi * V) * P_k), 0)
-    return jax.lax.scan(step, phi, t_r)[0]
+    return _loop
 
 
 @jax.jit

--- a/lys_em/multislice.py
+++ b/lys_em/multislice.py
@@ -20,18 +20,19 @@ def multislice(pot, tem, probe="TEM", postprocess="square", sum=False, use_check
         phi (numpy.ndarray) : The multislice simulation result.
     """
     sp = pot.space
+    t_r = pot.getTransmissionFunction(tem)
     postprocess = init_postprocess(postprocess)
 
     params = tem.asdict(len(jax.devices()))
-    calc_phi = single_func(pot, tem, probe, use_checkpoint=use_checkpoint)
-    
-    init = jnp.zeros((1 if isinstance(probe, str) else len(probe),sp.N[0],sp.N[1]), dtype=jnp.float32)
+    calc_phi = single_func(pot, probe, use_checkpoint=use_checkpoint) # calc_phi(param, t_r) -> phi
+
+    init = jnp.zeros((1 if isinstance(probe, str) else len(probe),sp.N[0],sp.N[1]), dtype=jnp.complex64)
     @jax.jit
     @checkpoint
-    def local_dev(x):
+    def local_dev(x, t_r):
         init_varying = jax.lax.pcast(init, "i", to="varying")
         def _post(carry, param):
-            phi = calc_phi(param)
+            phi = calc_phi(param, t_r)
             post = postprocess(phi)
             return carry + post, None if sum else post
         
@@ -43,10 +44,10 @@ def multislice(pot, tem, probe="TEM", postprocess="square", sum=False, use_check
 
     # Parallelization: "calc" function perform multislice calculation for list of parameters in tem. 
     calc = shard_map(local_dev,
-            mesh=jax.sharding.Mesh(jax.devices(), ('i',)), in_specs=P('i'), out_specs= P(None,None,None) if sum else P('i',None,None,None))
+            mesh=jax.sharding.Mesh(jax.devices(), ('i',)), in_specs=(P('i'), P()), out_specs= P(None,None,None) if sum else P('i',None,None,None))
 
     # Move to main, remove padding and unnecessary axis
-    phi = jax.device_get(calc(params))    # (nparams, nprobe, Nx, Ny)
+    phi = jax.device_get(calc(params, t_r))    # (nparams, nprobe, Nx, Ny)
     return phi
 
 
@@ -57,9 +58,8 @@ def init_postprocess(post):
         return lambda x: abs(x)**2
 
 
-def single_func(pot, tem, probe, use_checkpoint=False):
+def single_func(pot, probe, use_checkpoint=False):
     sp = pot.space.asdict()
-    t_r = pot.getTransmissionFunction(tem)
     probes = probe if not isinstance(probe, str) else jnp.array([jnp.fft.ifft2(jnp.ones(pot.space.N[:2]))])
 
     @jax.jit
@@ -72,7 +72,7 @@ def single_func(pot, tem, probe, use_checkpoint=False):
 
     @jax.jit
     @checkpoint
-    def _loop(tem_i):
+    def _loop(tem_i, t_r):
         phi = getWaveFunction(sp, tem_i, probes) # shape (nprobe, Nx, Ny)
         phi = run_single_param(phi,sp, tem_i, t_r)
 

--- a/lys_em/potentials/generalPotential.py
+++ b/lys_em/potentials/generalPotential.py
@@ -9,14 +9,18 @@ class GeneralPotential(PotentialInterface):
         super().__init__(space)
         self._sp = space
         if isTransFunc:
+            @jax.jit
+            def mask(tf):
+                return jnp.fft.ifft2(jnp.fft.fft2(tf) * space.mask)
+
             self._pot = None
-            self._transFunc = potential
+            self._transFunc = jax.vmap(mask)(potential)
         else:
             self._pot = potential
             self._transFunc = None
 
-    def replace(self, potential, isTransFunc=False):
-        return GeneralPotential(self._sp, potential, isTransFunc=isTransFunc)
+    def replace(self, potential):
+        return GeneralPotential(self._sp, potential, isTransFunc=self._transFunc is not None)
 
     def getPhase(self, beam):
         if self._pot is not None:
@@ -25,11 +29,7 @@ class GeneralPotential(PotentialInterface):
             return jnp.unwrap(jnp.unwrap(jnp.angle(self._transFunc), axis=-2), axis=-1)
 
     def getTransmissionFunction(self, beam):
-        @jax.jit
-        def mask(tf):
-            return jnp.fft.ifft2(jnp.fft.fft2(tf) * self._space.mask)
-
         if self._transFunc is not None:
-            return jax.vmap(mask)(self._transFunc)
+            return self._transFunc
         else:
             return super().getTransmissionFunction(beam)


### PR DESCRIPTION
I have performed some performance improvement for grad calculation.
 6 GPU Result:
python speedtest_grad.py 1 4096 20 400 True
---
jax_num_cpu_devices:  6
Nx, Ny:  4096
Number of slice:  20
Number of TEMParameter:  400
use checkpoint:  True
initial peak: 1.087 GB
  now memory: 1.087 GB
(1, 4096, 4096)
-----1st calc-----
 time       : 25.10 s
 peak memory: 11.061 GB
  net memory: 9.974 GB
  now memory: 6.306 GB
(1, 4096, 4096)
-----2nd calc-----
 time       : 22.91 s
 peak memory: 12.344 GB
  net memory: 11.257 GB
  now memory: 6.346 GB
(1, 4096, 4096)
-----3rd calc-----
 time       : 22.79 s
 peak memory: 12.349 GB
  net memory: 11.263 GB
  now memory: 6.475 GB
-----Average-----
 time       :22.85 s